### PR TITLE
Wfa0m rethrow errors on failed route registration

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const createError = require("./http-response-handlers").createError;
+
 function register(basePath, {models, authenticator, swagger, logger, simpleDao, config, limiter}) {
   const fs = require("fs");
   const resources = fs.readdirSync(basePath);
@@ -31,6 +33,7 @@ function register(basePath, {models, authenticator, swagger, logger, simpleDao, 
             });
           } catch (e) {
             logger.error("register:error", handlerPath, e);
+            throw createError(e);
           }
         });
       }
@@ -41,6 +44,7 @@ function register(basePath, {models, authenticator, swagger, logger, simpleDao, 
           _models.models = Object.assign(_models.models, resourceModels);
         } catch (e) {
           logger.error("register:error", modelsPath, e);
+          throw createError(e);
         }
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btrz-http-service",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "HTTP related utilities for Betterez APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently, if route registration throws an error, the error is logged & swallowed, and the route is not registered.  This means that the server may start up correctly, but requests to that route will return a 404.  We saw this happen in Sandbox recently when a change to the stripe npm module caused certain routes to fail registration.

A failed route registration should rethrow the error so that the server will crash instead of starting with only some of its routes available.
https://app.clickup.com/t/wfa0m